### PR TITLE
fix(core): address critical bugs and improve thread safety

### DIFF
--- a/src/libraries/Hexalith.KeyValueStorages.Abstractions/IState.cs
+++ b/src/libraries/Hexalith.KeyValueStorages.Abstractions/IState.cs
@@ -15,7 +15,7 @@ public interface IState
     /// <summary>
     /// Gets the name of the state.
     /// </summary>
-    static abstract IState Name { get; }
+    static abstract string Name { get; }
 
     /// <summary>
     /// Gets the etag of the state.

--- a/src/libraries/Hexalith.KeyValueStorages.DaprComponents/Actors/KeyValueStoreActor{TState}.cs
+++ b/src/libraries/Hexalith.KeyValueStorages.DaprComponents/Actors/KeyValueStoreActor{TState}.cs
@@ -105,12 +105,12 @@ public class KeyValueStoreActor<TState>(ActorHost host)
         {
             Etag = UniqueIdHelper.GenerateUniqueStringId(),  // Generate a new Etag
         };
-        if (value.TimeToLive is not null)
+        if (newValue.TimeToLive is not null)
         {
             await StateManager.SetStateAsync(
                 _stateName,
-                value,
-                value.TimeToLive.Value,
+                newValue,
+                newValue.TimeToLive.Value,
                 cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -118,7 +118,7 @@ public class KeyValueStoreActor<TState>(ActorHost host)
         {
             await StateManager.SetStateAsync(
                 _stateName,
-                value,
+                newValue,
                 cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/src/libraries/Hexalith.KeyValueStorages.Files/FileKeyValueStorage.cs
+++ b/src/libraries/Hexalith.KeyValueStorages.Files/FileKeyValueStorage.cs
@@ -14,7 +14,6 @@ using Hexalith.Commons.Configurations;
 using Hexalith.Commons.UniqueIds;
 using Hexalith.KeyValueStorages;
 using Hexalith.KeyValueStorages.Exceptions;
-using Hexalith.KeyValueStorages.Helpers;
 
 using Microsoft.Extensions.Options;
 
@@ -44,7 +43,7 @@ public abstract class FileKeyValueStorage<TKey, TState>
         string? container = null,
         string? entity = null,
         TimeProvider? timeProvider = null)
-        : base(settings, database, container, GetEntity(entity), timeProvider)
+        : base(settings, database, container, entity, timeProvider)
     {
         SettingsException.ThrowIfUndefined<KeyValueStoreSettings>(settings?.Value.StorageRootPath);
         _rootPath = settings.Value.StorageRootPath;
@@ -238,16 +237,6 @@ public abstract class FileKeyValueStorage<TKey, TState>
         await using FileStream stream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
         await WriteToStreamAsync(stream, value, cancellationToken).ConfigureAwait(false);
         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static string GetEntity(string? entity)
-    {
-        if (string.IsNullOrWhiteSpace(entity))
-        {
-            return StateHelper.GetStateName<TState>();
-        }
-
-        return entity;
     }
 
     private async Task<TState?> ReadAsync(string filePath, CancellationToken cancellationToken)


### PR DESCRIPTION
- Fix InMemoryKeyValueStore.AddOrUpdateAsync race condition by performing check-and-update atomically within lock scope
- Fix InMemoryKeyValueStore.ExistsAsync to check TTL expiration
- Fix InMemoryKeyValueStore.RemoveAsync memory leak by cleaning up _timeToLive dictionary entries
- Fix InMemoryKeyValueStore.TryGetAsync unnecessary async overhead
- Fix InMemoryKeyValueStore.Clear and TimeToLiveCleanup collection modification during iteration by materializing keys first
- Fix KeyValueStoreActor.SetAsync saving wrong value (value instead of newValue with updated Etag)
- Fix DaprActorKeyValueStore.AddOrUpdateAsync to perform proper add-or-update logic instead of always calling AddAsync
- Fix DaprActorKeyValueStore.ExistsAsync NotImplementedException
- Fix IState.Name return type from IState to string
- Remove duplicate GetEntity method from FileKeyValueStorage