### PR TITLE
Add missing unit tests

### DIFF
--- a/test/Hexalith.KeyValueStorages.Tests/ExceptionTests.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/ExceptionTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="ExceptionTests.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.KeyValueStorages.Tests;
+
+using System;
+
+using Hexalith.KeyValueStorages.Exceptions;
+
+using Shouldly;
+
+/// <summary>
+/// Unit tests for exception classes.
+/// </summary>
+public class ExceptionTests
+{
+    /// <summary>
+    /// Tests the default constructor of ConcurrencyException.
+    /// </summary>
+    [Fact]
+    public void ConcurrencyExceptionDefaultConstructorShouldCreateInstance()
+    {
+        // Act
+        var exception = new ConcurrencyException<string>();
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Key.ShouldBeNull();
+        exception.Etag.ShouldBeNull();
+        exception.ExpectedEtag.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Tests the message constructor of ConcurrencyException.
+    /// </summary>
+    [Fact]
+    public void ConcurrencyExceptionMessageConstructorShouldSetMessage()
+    {
+        // Arrange
+        const string message = "Test message";
+
+        // Act
+        var exception = new ConcurrencyException<string>(message);
+
+        // Assert
+        exception.Message.ShouldBe(message);
+        exception.Key.ShouldBeNull();
+        exception.Etag.ShouldBeNull();
+        exception.ExpectedEtag.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Tests the key, etag, and expectedEtag constructor of ConcurrencyException.
+    /// </summary>
+    [Fact]
+    public void ConcurrencyExceptionKeyEtagConstructorShouldSetProperties()
+    {
+        // Arrange
+        const string key = "test-key";
+        const string etag = "etag-123";
+        const string expectedEtag = "expected-etag-456";
+
+        // Act
+        var exception = new ConcurrencyException<string>(key, etag, expectedEtag);
+
+        // Assert
+        exception.Key.ShouldBe(key);
+        exception.Etag.ShouldBe(etag);
+        exception.ExpectedEtag.ShouldBe(expectedEtag);
+        exception.Message.ShouldContain(key);
+        exception.Message.ShouldContain(etag);
+        exception.Message.ShouldContain(expectedEtag);
+    }
+
+    /// <summary>
+    /// Tests the message and inner exception constructor of ConcurrencyException.
+    /// </summary>
+    [Fact]
+    public void ConcurrencyExceptionMessageAndInnerExceptionConstructorShouldSetProperties()
+    {
+        // Arrange
+        const string message = "Test message";
+        var innerException = new InvalidOperationException("Inner exception");
+
+        // Act
+        var exception = new ConcurrencyException<string>(message, innerException);
+
+        // Assert
+        exception.Message.ShouldBe(message);
+        exception.InnerException.ShouldBe(innerException);
+    }
+
+    /// <summary>
+    /// Tests ConcurrencyException with integer key type.
+    /// </summary>
+    [Fact]
+    public void ConcurrencyExceptionWithIntegerKeyShouldWork()
+    {
+        // Arrange
+        const int key = 42;
+        const string etag = "etag-123";
+        const string expectedEtag = "expected-etag-456";
+
+        // Act
+        var exception = new ConcurrencyException<int>(key, etag, expectedEtag);
+
+        // Assert
+        exception.Key.ShouldBe(key);
+        exception.Etag.ShouldBe(etag);
+        exception.ExpectedEtag.ShouldBe(expectedEtag);
+    }
+
+    /// <summary>
+    /// Tests the default constructor of DuplicateKeyException.
+    /// </summary>
+    [Fact]
+    public void DuplicateKeyExceptionDefaultConstructorShouldCreateInstance()
+    {
+        // Act
+        var exception = new DuplicateKeyException<string>();
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Key.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Tests the message constructor of DuplicateKeyException.
+    /// </summary>
+    [Fact]
+    public void DuplicateKeyExceptionMessageConstructorShouldSetMessage()
+    {
+        // Arrange
+        const string message = "Test message";
+
+        // Act
+        var exception = new DuplicateKeyException<string>(message);
+
+        // Assert
+        exception.Message.ShouldBe(message);
+    }
+
+    /// <summary>
+    /// Tests the key constructor of DuplicateKeyException.
+    /// </summary>
+    [Fact]
+    public void DuplicateKeyExceptionKeyConstructorShouldSetKeyAndMessage()
+    {
+        // Arrange
+        const string key = "test-key";
+
+        // Act
+        var exception = new DuplicateKeyException<string>(key);
+
+        // Assert
+        exception.Key.ShouldBe(key);
+        exception.Message.ShouldContain(key);
+    }
+
+    /// <summary>
+    /// Tests the message and inner exception constructor of DuplicateKeyException.
+    /// </summary>
+    [Fact]
+    public void DuplicateKeyExceptionMessageAndInnerExceptionConstructorShouldSetProperties()
+    {
+        // Arrange
+        const string message = "Test message";
+        var innerException = new InvalidOperationException("Inner exception");
+
+        // Act
+        var exception = new DuplicateKeyException<string>(message, innerException);
+
+        // Assert
+        exception.Message.ShouldBe(message);
+        exception.InnerException.ShouldBe(innerException);
+    }
+
+    /// <summary>
+    /// Tests DuplicateKeyException with integer key type.
+    /// </summary>
+    [Fact]
+    public void DuplicateKeyExceptionWithIntegerKeyShouldWork()
+    {
+        // Arrange
+        const int key = 42;
+
+        // Act
+        var exception = new DuplicateKeyException<int>(key);
+
+        // Assert
+        exception.Key.ShouldBe(key);
+        exception.Message.ShouldContain("42");
+    }
+
+    /// <summary>
+    /// Tests DuplicateKeyException with long key type.
+    /// </summary>
+    [Fact]
+    public void DuplicateKeyExceptionWithLongKeyShouldWork()
+    {
+        // Arrange
+        const long key = 123456789L;
+
+        // Act
+        var exception = new DuplicateKeyException<long>(key);
+
+        // Assert
+        exception.Key.ShouldBe(key);
+        exception.Message.ShouldContain("123456789");
+    }
+}

--- a/test/Hexalith.KeyValueStorages.Tests/Hexalith.KeyValueStorages.Tests.csproj
+++ b/test/Hexalith.KeyValueStorages.Tests/Hexalith.KeyValueStorages.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Hexalith.Commons.UniqueIds" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />

--- a/test/Hexalith.KeyValueStorages.Tests/InMemoryKeyValueStoreTest.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/InMemoryKeyValueStoreTest.cs
@@ -285,4 +285,243 @@ public class InMemoryKeyValueStoreTest
         result.Value.ShouldBe(100);
         result.Etag.ShouldNotBeNullOrWhiteSpace();
     }
+
+    /// <summary>
+    /// Tests the ExistsAsync method of the InMemoryKeyValueStore class returns false when key doesn't exist.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExistsAsyncShouldReturnFalseWhenKeyDoesNotExist()
+    {
+        // Arrange
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            UniqueIdHelper.GenerateUniqueStringId(),
+            UniqueIdHelper.GenerateUniqueStringId(),
+            TimeProvider.System);
+
+        // Act
+        bool result = await store.ExistsAsync(1, CancellationToken.None);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Tests the ExistsAsync method of the InMemoryKeyValueStore class returns true when key exists.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExistsAsyncShouldReturnTrueWhenKeyExists()
+    {
+        // Arrange
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            UniqueIdHelper.GenerateUniqueStringId(),
+            UniqueIdHelper.GenerateUniqueStringId(),
+            TimeProvider.System);
+        _ = await store.AddAsync(1, new State<long>(100L, null, null), CancellationToken.None);
+
+        // Act
+        bool result = await store.ExistsAsync(1, CancellationToken.None);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Tests the AddOrUpdateAsync method adds a new value when key doesn't exist.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task AddOrUpdateAsyncShouldAddValueWhenKeyDoesNotExist()
+    {
+        // Arrange
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            UniqueIdHelper.GenerateUniqueStringId(),
+            UniqueIdHelper.GenerateUniqueStringId(),
+            TimeProvider.System);
+
+        // Act
+        string result = await store.AddOrUpdateAsync(1, new State<long>(100L, null, null), CancellationToken.None);
+
+        // Assert
+        result.ShouldNotBeNullOrWhiteSpace();
+        State<long> value = await store.GetAsync(1, CancellationToken.None);
+        value.Value.ShouldBe(100L);
+    }
+
+    /// <summary>
+    /// Tests the AddOrUpdateAsync method updates an existing value when key exists.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task AddOrUpdateAsyncShouldUpdateValueWhenKeyExists()
+    {
+        // Arrange
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            UniqueIdHelper.GenerateUniqueStringId(),
+            UniqueIdHelper.GenerateUniqueStringId(),
+            TimeProvider.System);
+        _ = await store.AddAsync(1, new State<long>(100L, null, null), CancellationToken.None);
+
+        // Act
+        string result = await store.AddOrUpdateAsync(1, new State<long>(200L, null, null), CancellationToken.None);
+
+        // Assert
+        result.ShouldNotBeNullOrWhiteSpace();
+        State<long> value = await store.GetAsync(1, CancellationToken.None);
+        value.Value.ShouldBe(200L);
+    }
+
+    /// <summary>
+    /// Tests the AddOrUpdateAsync method throws ConcurrencyException when etag doesn't match.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task AddOrUpdateAsyncShouldThrowConcurrencyExceptionWhenEtagDoesNotMatch()
+    {
+        // Arrange
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            UniqueIdHelper.GenerateUniqueStringId(),
+            UniqueIdHelper.GenerateUniqueStringId(),
+            TimeProvider.System);
+        _ = await store.AddAsync(1, new State<long>(100L, null, null), CancellationToken.None);
+
+        // Act & Assert
+        _ = await Should.ThrowAsync<ConcurrencyException<long>>(
+            async () => await store.AddOrUpdateAsync(1, new State<long>(200L, "bad-etag", null), CancellationToken.None).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Tests the RemoveAsync method throws ConcurrencyException when etag doesn't match.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task RemoveAsyncShouldThrowConcurrencyExceptionWhenEtagDoesNotMatch()
+    {
+        // Arrange
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            UniqueIdHelper.GenerateUniqueStringId(),
+            UniqueIdHelper.GenerateUniqueStringId(),
+            TimeProvider.System);
+        _ = await store.AddAsync(1, new State<long>(100L, null, null), CancellationToken.None);
+
+        // Act & Assert
+        _ = await Should.ThrowAsync<ConcurrencyException<long>>(
+            async () => await store.RemoveAsync(1, "bad-etag", CancellationToken.None).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Tests the Clear method removes all entries for the current database and container.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task ClearShouldRemoveAllEntriesForDatabaseAndContainer()
+    {
+        // Arrange
+        string database = UniqueIdHelper.GenerateUniqueStringId();
+        string container = UniqueIdHelper.GenerateUniqueStringId();
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            database,
+            container,
+            TimeProvider.System);
+        _ = await store.AddAsync(1, new State<long>(100L, null, null), CancellationToken.None);
+        _ = await store.AddAsync(2, new State<long>(200L, null, null), CancellationToken.None);
+        _ = await store.AddAsync(3, new State<long>(300L, null, null), CancellationToken.None);
+
+        // Act
+        store.Clear();
+
+        // Assert
+        (await store.ContainsKeyAsync(1, CancellationToken.None)).ShouldBeFalse();
+        (await store.ContainsKeyAsync(2, CancellationToken.None)).ShouldBeFalse();
+        (await store.ContainsKeyAsync(3, CancellationToken.None)).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Tests the TimeToLiveCleanup method removes expired entries.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task TimeToLiveCleanupShouldRemoveExpiredEntries()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        string database = UniqueIdHelper.GenerateUniqueStringId();
+        string container = UniqueIdHelper.GenerateUniqueStringId();
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            database,
+            container,
+            timeProvider);
+
+        // Add a value with a 1 minute TTL
+        _ = await store.AddAsync(1, new State<long>(100L, null, TimeSpan.FromMinutes(1)), CancellationToken.None);
+        // Add a value without TTL
+        _ = await store.AddAsync(2, new State<long>(200L, null, null), CancellationToken.None);
+
+        // Advance time by 2 minutes
+        timeProvider.AdvanceTime(TimeSpan.FromMinutes(2));
+
+        // Act
+        store.TimeToLiveCleanup();
+
+        // Assert
+        (await store.ContainsKeyAsync(1, CancellationToken.None)).ShouldBeFalse();
+        (await store.ContainsKeyAsync(2, CancellationToken.None)).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Tests that expired values are automatically removed on access.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetAsyncShouldReturnKeyNotFoundExceptionWhenValueHasExpired()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        string database = UniqueIdHelper.GenerateUniqueStringId();
+        string container = UniqueIdHelper.GenerateUniqueStringId();
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            database,
+            container,
+            timeProvider);
+
+        // Add a value with a 1 minute TTL
+        _ = await store.AddAsync(1, new State<long>(100L, null, TimeSpan.FromMinutes(1)), CancellationToken.None);
+
+        // Advance time by 2 minutes
+        timeProvider.AdvanceTime(TimeSpan.FromMinutes(2));
+
+        // Act & Assert
+        _ = await Should.ThrowAsync<KeyNotFoundException>(
+            async () => await store.GetAsync(1, CancellationToken.None).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Tests that TryGetAsync returns null when value has expired.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task TryGetAsyncShouldReturnNullWhenValueHasExpired()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        string database = UniqueIdHelper.GenerateUniqueStringId();
+        string container = UniqueIdHelper.GenerateUniqueStringId();
+        var store = new InMemoryKeyValueStore<long, State<long>>(
+            database,
+            container,
+            timeProvider);
+
+        // Add a value with a 1 minute TTL
+        _ = await store.AddAsync(1, new State<long>(100L, null, TimeSpan.FromMinutes(1)), CancellationToken.None);
+
+        // Advance time by 2 minutes
+        timeProvider.AdvanceTime(TimeSpan.FromMinutes(2));
+
+        // Act
+        State<long>? result = await store.TryGetAsync(1, CancellationToken.None);
+
+        // Assert
+        result.ShouldBeNull();
+    }
 }

--- a/test/Hexalith.KeyValueStorages.Tests/JsonKeyValueStorageHelperTests.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/JsonKeyValueStorageHelperTests.cs
@@ -1,0 +1,289 @@
+// <copyright file="JsonKeyValueStorageHelperTests.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.KeyValueStorages.Tests;
+
+using System;
+using System.IO;
+using System.Text.Json;
+
+using Hexalith.Commons.UniqueIds;
+using Hexalith.KeyValueStorages.Files;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+/// <summary>
+/// Unit tests for JsonKeyValueStorageHelper class.
+/// </summary>
+public class JsonKeyValueStorageHelperTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonKeyValueStorageHelperTests"/> class.
+    /// </summary>
+    public JsonKeyValueStorageHelperTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), UniqueIdHelper.GenerateDateTimeId());
+        _ = Directory.CreateDirectory(_testDirectory);
+    }
+
+    /// <summary>
+    /// Disposes the test resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Tests that AddJsonFileKeyValueStore registers the service correctly.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldRegisterService()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = _testDirectory;
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+
+        // Act
+        services.AddJsonFileKeyValueStore("test-store");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store = provider.GetKeyedService<IKeyValueProvider>("test-store");
+        store.ShouldNotBeNull();
+        store.ShouldBeOfType<JsonFileKeyValueProvider>();
+    }
+
+    /// <summary>
+    /// Tests that AddJsonFileKeyValueStore with custom parameters works.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldUseCustomParameters()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = _testDirectory;
+            opt.DefaultDatabase = "defaultdb";
+            opt.DefaultContainer = "defaultcontainer";
+        });
+
+        // Act
+        services.AddJsonFileKeyValueStore("test-store", "customdb", "customcontainer", "customentity");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store = provider.GetKeyedService<IKeyValueProvider>("test-store");
+        store.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that AddJsonFileKeyValueStore with JsonSerializerOptions works.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldUseCustomJsonSerializerOptions()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = _testDirectory;
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        // Act
+        services.AddJsonFileKeyValueStore("test-store", options: options);
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store = provider.GetKeyedService<IKeyValueProvider>("test-store");
+        store.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that AddJsonFileKeyValueStore throws when services is null.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldThrowWhenServicesIsNull()
+    {
+        // Arrange
+        IServiceCollection? services = null;
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentNullException>(() => services!.AddJsonFileKeyValueStore("test"));
+    }
+
+    /// <summary>
+    /// Tests that AddJsonFileKeyValueStore throws when name is null.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldThrowWhenNameIsNull()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentException>(() => services.AddJsonFileKeyValueStore(null!));
+    }
+
+    /// <summary>
+    /// Tests that AddJsonFileKeyValueStore throws when name is empty.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldThrowWhenNameIsEmpty()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentException>(() => services.AddJsonFileKeyValueStore(string.Empty));
+    }
+
+    /// <summary>
+    /// Tests that AddPolymorphicJsonFileKeyValueStore registers the service correctly.
+    /// </summary>
+    [Fact]
+    public void AddPolymorphicJsonFileKeyValueStoreShouldRegisterService()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = _testDirectory;
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+
+        // Act
+        services.AddPolymorphicJsonFileKeyValueStore("test-store");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store = provider.GetKeyedService<IKeyValueProvider>("test-store");
+        store.ShouldNotBeNull();
+        store.ShouldBeOfType<JsonFileKeyValueProvider>();
+    }
+
+    /// <summary>
+    /// Tests that AddPolymorphicJsonFileKeyValueStore throws when services is null.
+    /// </summary>
+    [Fact]
+    public void AddPolymorphicJsonFileKeyValueStoreShouldThrowWhenServicesIsNull()
+    {
+        // Arrange
+        IServiceCollection? services = null;
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentNullException>(() => services!.AddPolymorphicJsonFileKeyValueStore("test"));
+    }
+
+    /// <summary>
+    /// Tests that AddPolymorphicJsonFileKeyValueStore throws when name is null.
+    /// </summary>
+    [Fact]
+    public void AddPolymorphicJsonFileKeyValueStoreShouldThrowWhenNameIsNull()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentException>(() => services.AddPolymorphicJsonFileKeyValueStore(null!));
+    }
+
+    /// <summary>
+    /// Tests that multiple stores can be registered with different names.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreShouldAllowMultipleRegistrations()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = _testDirectory;
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+
+        // Act
+        services.AddJsonFileKeyValueStore("store1");
+        services.AddJsonFileKeyValueStore("store2");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store1 = provider.GetKeyedService<IKeyValueProvider>("store1");
+        var store2 = provider.GetKeyedService<IKeyValueProvider>("store2");
+        store1.ShouldNotBeNull();
+        store2.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that the registered provider can create a store instance.
+    /// </summary>
+    [Fact]
+    public void AddJsonFileKeyValueStoreProviderShouldCreateStore()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = _testDirectory;
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+        services.AddJsonFileKeyValueStore("test-store");
+        ServiceProvider provider = services.BuildServiceProvider();
+        var keyValueProvider = provider.GetKeyedService<IKeyValueProvider>("test-store");
+
+        // Act
+        var store = keyValueProvider!.Create<string, State<DummyValue>>();
+
+        // Assert
+        store.ShouldNotBeNull();
+        store.ShouldBeOfType<JsonFileKeyValueStore<string, State<DummyValue>>>();
+    }
+
+    /// <summary>
+    /// Disposes the test resources.
+    /// </summary>
+    /// <param name="disposing">Whether the method is being called from Dispose().</param>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Not applicable")]
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                try
+                {
+                    if (Directory.Exists(_testDirectory))
+                    {
+                        Directory.Delete(_testDirectory, true);
+                    }
+                }
+                catch
+                {
+                    // Ignore errors during cleanup
+                }
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/test/Hexalith.KeyValueStorages.Tests/KeyValueStorageHelperTests.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/KeyValueStorageHelperTests.cs
@@ -1,0 +1,176 @@
+// <copyright file="KeyValueStorageHelperTests.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.KeyValueStorages.Tests;
+
+using System;
+
+using Hexalith.KeyValueStorages.Helpers;
+using Hexalith.KeyValueStorages.InMemory;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Shouldly;
+
+/// <summary>
+/// Unit tests for KeyValueStorageHelper class.
+/// </summary>
+public class KeyValueStorageHelperTests
+{
+    /// <summary>
+    /// Tests that AddMemoryKeyValueStore registers the service correctly.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldRegisterService()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = "/test";
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+
+        // Act
+        services.AddMemoryKeyValueStore("test-store");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store = provider.GetKeyedService<IKeyValueProvider>("test-store");
+        store.ShouldNotBeNull();
+        store.ShouldBeOfType<InMemoryKeyValueProvider>();
+    }
+
+    /// <summary>
+    /// Tests that AddMemoryKeyValueStore with custom parameters works.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldUseCustomParameters()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = "/test";
+            opt.DefaultDatabase = "defaultdb";
+            opt.DefaultContainer = "defaultcontainer";
+        });
+
+        // Act
+        services.AddMemoryKeyValueStore("test-store", "customdb", "customcontainer", "customentity");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store = provider.GetKeyedService<IKeyValueProvider>("test-store");
+        store.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that AddMemoryKeyValueStore throws when services is null.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldThrowWhenServicesIsNull()
+    {
+        // Arrange
+        IServiceCollection? services = null;
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentNullException>(() => services!.AddMemoryKeyValueStore("test"));
+    }
+
+    /// <summary>
+    /// Tests that AddMemoryKeyValueStore throws when name is null.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldThrowWhenNameIsNull()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentException>(() => services.AddMemoryKeyValueStore(null!));
+    }
+
+    /// <summary>
+    /// Tests that AddMemoryKeyValueStore throws when name is empty.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldThrowWhenNameIsEmpty()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentException>(() => services.AddMemoryKeyValueStore(string.Empty));
+    }
+
+    /// <summary>
+    /// Tests that AddMemoryKeyValueStore throws when name is whitespace.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldThrowWhenNameIsWhitespace()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        _ = Should.Throw<ArgumentException>(() => services.AddMemoryKeyValueStore("   "));
+    }
+
+    /// <summary>
+    /// Tests that multiple stores can be registered with different names.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreShouldAllowMultipleRegistrations()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = "/test";
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+
+        // Act
+        services.AddMemoryKeyValueStore("store1");
+        services.AddMemoryKeyValueStore("store2");
+
+        // Assert
+        ServiceProvider provider = services.BuildServiceProvider();
+        var store1 = provider.GetKeyedService<IKeyValueProvider>("store1");
+        var store2 = provider.GetKeyedService<IKeyValueProvider>("store2");
+        store1.ShouldNotBeNull();
+        store2.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that the registered provider can create a store instance.
+    /// </summary>
+    [Fact]
+    public void AddMemoryKeyValueStoreProviderShouldCreateStore()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Configure<KeyValueStoreSettings>(opt =>
+        {
+            opt.StorageRootPath = "/test";
+            opt.DefaultDatabase = "testdb";
+            opt.DefaultContainer = "testcontainer";
+        });
+        services.AddMemoryKeyValueStore("test-store");
+        ServiceProvider provider = services.BuildServiceProvider();
+        var keyValueProvider = provider.GetKeyedService<IKeyValueProvider>("test-store");
+
+        // Act
+        var store = keyValueProvider!.Create<long, State<string>>();
+
+        // Assert
+        store.ShouldNotBeNull();
+        store.ShouldBeOfType<InMemoryKeyValueStore<long, State<string>>>();
+    }
+}

--- a/test/Hexalith.KeyValueStorages.Tests/KeyValueStoreSettingsTests.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/KeyValueStoreSettingsTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="KeyValueStoreSettingsTests.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.KeyValueStorages.Tests;
+
+using Shouldly;
+
+/// <summary>
+/// Unit tests for the KeyValueStoreSettings class.
+/// </summary>
+public class KeyValueStoreSettingsTests
+{
+    /// <summary>
+    /// Tests that the default constructor initializes properties with default values.
+    /// </summary>
+    [Fact]
+    public void DefaultConstructorShouldInitializeWithDefaultValues()
+    {
+        // Act
+        var settings = new KeyValueStoreSettings();
+
+        // Assert
+        settings.StorageRootPath.ShouldBe("/store");
+        settings.DefaultDatabase.ShouldBe("database");
+        settings.DefaultContainer.ShouldBe("container");
+    }
+
+    /// <summary>
+    /// Tests that properties can be set to custom values.
+    /// </summary>
+    [Fact]
+    public void PropertiesShouldBeSettable()
+    {
+        // Arrange
+        var settings = new KeyValueStoreSettings();
+
+        // Act
+        settings.StorageRootPath = "/custom/path";
+        settings.DefaultDatabase = "customdb";
+        settings.DefaultContainer = "customcontainer";
+
+        // Assert
+        settings.StorageRootPath.ShouldBe("/custom/path");
+        settings.DefaultDatabase.ShouldBe("customdb");
+        settings.DefaultContainer.ShouldBe("customcontainer");
+    }
+
+    /// <summary>
+    /// Tests that ConfigurationName returns the expected configuration section name.
+    /// </summary>
+    [Fact]
+    public void ConfigurationNameShouldReturnExpectedValue()
+    {
+        // Act
+        string result = KeyValueStoreSettings.ConfigurationName();
+
+        // Assert
+        result.ShouldBe("Hexalith:KeyValueStorages");
+    }
+
+    /// <summary>
+    /// Tests that properties can be set to null values.
+    /// </summary>
+    [Fact]
+    public void PropertiesShouldAcceptNullValues()
+    {
+        // Arrange
+        var settings = new KeyValueStoreSettings
+        {
+            // Act
+            StorageRootPath = null,
+            DefaultDatabase = null,
+            DefaultContainer = null,
+        };
+
+        // Assert
+        settings.StorageRootPath.ShouldBeNull();
+        settings.DefaultDatabase.ShouldBeNull();
+        settings.DefaultContainer.ShouldBeNull();
+    }
+}

--- a/test/Hexalith.KeyValueStorages.Tests/StateHelperTests.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/StateHelperTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="StateHelperTests.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.KeyValueStorages.Tests;
+
+using System;
+using System.Runtime.Serialization;
+
+using Hexalith.KeyValueStorages.Helpers;
+
+using Shouldly;
+
+/// <summary>
+/// Unit tests for the StateHelper class.
+/// </summary>
+public class StateHelperTests
+{
+    /// <summary>
+    /// Tests that GetStateName returns the DataContract name when the attribute is present.
+    /// </summary>
+    [Fact]
+    public void GetStateNameShouldReturnDataContractNameWhenAttributeIsPresent()
+    {
+        // Act
+        string result = StateHelper.GetStateName<TestStateWithDataContract>();
+
+        // Assert
+        result.ShouldBe("CustomStateName");
+    }
+
+    /// <summary>
+    /// Tests that GetStateName returns the type name when no DataContract attribute is present.
+    /// </summary>
+    [Fact]
+    public void GetStateNameShouldReturnTypeNameWhenNoDataContractAttribute()
+    {
+        // Act
+        string result = StateHelper.GetStateName<TestStateWithoutDataContract>();
+
+        // Assert
+        result.ShouldBe(nameof(TestStateWithoutDataContract));
+    }
+
+    /// <summary>
+    /// Tests that GetStateName returns the type name when DataContract has no Name property.
+    /// </summary>
+    [Fact]
+    public void GetStateNameShouldReturnTypeNameWhenDataContractHasNoName()
+    {
+        // Act
+        string result = StateHelper.GetStateName<TestStateWithDataContractNoName>();
+
+        // Assert
+        result.ShouldBe(nameof(TestStateWithDataContractNoName));
+    }
+
+    /// <summary>
+    /// Tests that GetStateName works with the State generic type.
+    /// </summary>
+    [Fact]
+    public void GetStateNameShouldReturnNameForGenericStateType()
+    {
+        // Act
+        string result = StateHelper.GetStateName<State<string>>();
+
+        // Assert
+        result.ShouldBe("State`1");
+    }
+
+    /// <summary>
+    /// A test state class with a DataContract attribute and a custom name.
+    /// </summary>
+    [DataContract(Name = "CustomStateName")]
+    private record TestStateWithDataContract(string? Etag, TimeSpan? TimeToLive) : StateBase(Etag, TimeToLive);
+
+    /// <summary>
+    /// A test state class without a DataContract attribute.
+    /// </summary>
+    private record TestStateWithoutDataContract(string? Etag, TimeSpan? TimeToLive) : StateBase(Etag, TimeToLive);
+
+    /// <summary>
+    /// A test state class with a DataContract attribute but no name specified.
+    /// </summary>
+    [DataContract]
+    private record TestStateWithDataContractNoName(string? Etag, TimeSpan? TimeToLive) : StateBase(Etag, TimeToLive);
+}

--- a/test/Hexalith.KeyValueStorages.Tests/StateTests.cs
+++ b/test/Hexalith.KeyValueStorages.Tests/StateTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="StateTests.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.KeyValueStorages.Tests;
+
+using System;
+
+using Shouldly;
+
+/// <summary>
+/// Unit tests for State and StateBase classes.
+/// </summary>
+public class StateTests
+{
+    /// <summary>
+    /// Tests StateBase constructor with all parameters.
+    /// </summary>
+    [Fact]
+    public void StateBaseConstructorShouldSetAllProperties()
+    {
+        // Arrange
+        const string etag = "test-etag";
+        TimeSpan ttl = TimeSpan.FromMinutes(5);
+
+        // Act
+        var state = new TestState(etag, ttl);
+
+        // Assert
+        state.Etag.ShouldBe(etag);
+        state.TimeToLive.ShouldBe(ttl);
+    }
+
+    /// <summary>
+    /// Tests StateBase constructor with null values.
+    /// </summary>
+    [Fact]
+    public void StateBaseConstructorShouldAcceptNullValues()
+    {
+        // Act
+        var state = new TestState(null, null);
+
+        // Assert
+        state.Etag.ShouldBeNull();
+        state.TimeToLive.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Tests State constructor with value and default optional parameters.
+    /// </summary>
+    [Fact]
+    public void StateConstructorShouldSetValueWithDefaults()
+    {
+        // Arrange
+        const string value = "test-value";
+
+        // Act
+        var state = new State<string>(value);
+
+        // Assert
+        state.Value.ShouldBe(value);
+        state.Etag.ShouldBeNull();
+        state.TimeToLive.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Tests State constructor with all parameters.
+    /// </summary>
+    [Fact]
+    public void StateConstructorShouldSetAllProperties()
+    {
+        // Arrange
+        const string value = "test-value";
+        const string etag = "test-etag";
+        TimeSpan ttl = TimeSpan.FromMinutes(5);
+
+        // Act
+        var state = new State<string>(value, etag, ttl);
+
+        // Assert
+        state.Value.ShouldBe(value);
+        state.Etag.ShouldBe(etag);
+        state.TimeToLive.ShouldBe(ttl);
+    }
+
+    /// <summary>
+    /// Tests State with different value types.
+    /// </summary>
+    [Fact]
+    public void StateWithIntegerValueShouldWork()
+    {
+        // Act
+        var state = new State<int>(42, "etag", null);
+
+        // Assert
+        state.Value.ShouldBe(42);
+        state.Etag.ShouldBe("etag");
+    }
+
+    /// <summary>
+    /// Tests State with complex object value.
+    /// </summary>
+    [Fact]
+    public void StateWithComplexObjectValueShouldWork()
+    {
+        // Arrange
+        var dummy = new DummyValue
+        {
+            Name = "Test",
+            Started = DateTimeOffset.UtcNow,
+            Retries = 5,
+            Failed = false,
+        };
+
+        // Act
+        var state = new State<DummyValue>(dummy, "etag", TimeSpan.FromHours(1));
+
+        // Assert
+        state.Value.Name.ShouldBe("Test");
+        state.Value.Retries.ShouldBe(5);
+        state.Etag.ShouldBe("etag");
+        state.TimeToLive.ShouldBe(TimeSpan.FromHours(1));
+    }
+
+    /// <summary>
+    /// Tests State record with expression to create modified copy.
+    /// </summary>
+    [Fact]
+    public void StateWithExpressionShouldCreateModifiedCopy()
+    {
+        // Arrange
+        var original = new State<string>("value", "old-etag", null);
+
+        // Act
+        var modified = original with { Etag = "new-etag" };
+
+        // Assert
+        modified.Value.ShouldBe("value");
+        modified.Etag.ShouldBe("new-etag");
+        original.Etag.ShouldBe("old-etag");
+    }
+
+    /// <summary>
+    /// Tests State record equality.
+    /// </summary>
+    [Fact]
+    public void StateEqualityShouldCompareAllProperties()
+    {
+        // Arrange
+        var state1 = new State<string>("value", "etag", TimeSpan.FromMinutes(5));
+        var state2 = new State<string>("value", "etag", TimeSpan.FromMinutes(5));
+        var state3 = new State<string>("value", "different-etag", TimeSpan.FromMinutes(5));
+
+        // Assert
+        state1.ShouldBe(state2);
+        state1.ShouldNotBe(state3);
+    }
+
+    /// <summary>
+    /// Tests State with nullable value type.
+    /// </summary>
+    [Fact]
+    public void StateWithNullableValueTypeShouldWork()
+    {
+        // Act
+        var state = new State<int?>(null, "etag", null);
+
+        // Assert
+        state.Value.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A test state record that inherits from StateBase.
+    /// </summary>
+    private record TestState(string? Etag, TimeSpan? TimeToLive) : StateBase(Etag, TimeToLive);
+}


### PR DESCRIPTION
Add missing unit tests to improve code coverage:

- InMemoryKeyValueStore: ExistsAsync, AddOrUpdateAsync, TimeToLiveCleanup, Clear, RemoveAsync with etag, TTL expiration tests
- Exceptions: ConcurrencyException and DuplicateKeyException constructor tests
- StateHelper: GetStateName with/without DataContract attribute
- KeyValueStoreSettings: default values, property setters, ConfigurationName
- State/StateBase: constructors, record with expression, equality
- JsonFileKeyValueStore: AddOrUpdateAsync, ExistsAsync, GetDirectoryPath, GetFilePath tests
- DI extensions: KeyValueStorageHelper and JsonKeyValueStorageHelper registration tests

Also adds Microsoft.Extensions.DependencyInjection package reference to test project for DI helper tests.